### PR TITLE
Remove `"extraPaths": ["examples", "tests"],` from `pyrightconfig.json`

### DIFF
--- a/template/pyrightconfig.json
+++ b/template/pyrightconfig.json
@@ -2,7 +2,6 @@
   "typeCheckingMode": "strict",
   "include": ["src"],
   "ignore": ["tooling/pythonrc.py"],
-  "extraPaths": ["examples", "tests"],
   "reportMissingTypeStubs": "none",
   "reportMissingParameterType": "none",
   "reportUnknownArgumentType": "none",


### PR DESCRIPTION
Fixes #89