### PR TITLE
Fix `powershell` invocation for paths containing spaces

### DIFF
--- a/changelog/416.change.md
+++ b/changelog/416.change.md
@@ -1,0 +1,1 @@
+Fix `powershell` invocation for paths containing spaces

--- a/template/scripts/Sync-Py.ps1.jinja
+++ b/template/scripts/Sync-Py.ps1.jinja
@@ -32,7 +32,7 @@ if (!(Test-Path 'bin/uv*') -or !(bin/uv --version | Select-String $uvVersion)) {
         $uvInstaller = "$([System.IO.Path]::GetTempPath())$([System.Guid]::NewGuid()).ps1"
         Invoke-RestMethod "https://github.com/astral-sh/uv/releases/download/$uvVersion/uv-installer.ps1" |
             Out-File $uvInstaller
-        powershell -Command "$uvInstaller -NoModifyPath"
+        powershell -Command "& '$uvInstaller' -NoModifyPath"
     }
     else {
         'INSTALLING UV' | Write-Progress


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about any of the below, don't hesitate to ask. We're here to help! -->

# Description

<!--- Describe your changes in detail -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Test plan

<!--- Please describe in detail how you tested your changes. -->

## Checklist

- [x] My code follows this project's code style.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change is adequately tested.

## Terms

- [x] My contribution follows the [contributing guide](<https://github.com/blakeNaccarato/copier-python/blob/main/CONTRIBUTING.md>).
- [x] I agree to follow the [code of conduct](<https://github.com/blakeNaccarato/copier-python/blob/main/.github/CODE_OF_CONDUCT.md>).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an issue with the `powershell` invocation in the `Sync-Py.ps1.jinja` script, ensuring it correctly handles paths containing spaces. Additionally, a corresponding changelog entry has been added to document this fix.

* **Bug Fixes**:
    - Fixed `powershell` invocation to correctly handle paths containing spaces in the `Sync-Py.ps1.jinja` script.
* **Documentation**:
    - Added a changelog entry for the fix related to `powershell` invocation for paths containing spaces.

<!-- Generated by sourcery-ai[bot]: end summary -->